### PR TITLE
Fix consistent typo

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -6,7 +6,7 @@ HOME
    :caption: Boards:
 
    D1 <d1/index>
-   D1 mini Shileds <d1_mini_shiled/index>
+   D1 mini Shields <d1_mini_shiled/index>
    D32 <d32/index>
    W600 <w600/index>
 
@@ -41,7 +41,7 @@ Boards
 .. |D32_PRO_IMG| image:: ./_static/boards/d32_pro_v2.0.0_1_16x16.jpg
 .. _D32_PRO_IMG: ./d32/index.html
 
-.. _D1 mini Shileds: ./d1_mini_shiled/index.html
+.. _D1 mini Shields: ./d1_mini_shiled/index.html
 .. |SHT30_IMG| image:: ./_static/d1_shields/sht30_v2.1.0_1_16x16.jpg
 .. _SHT30_IMG: ./d1_mini_shiled/index.html
 


### PR DESCRIPTION
The directory name is obviously wrong as well (`d1_mini_shiled`) but that doesn't matter so much for readers.