### PR TITLE
Updating docs to reflect change in driver requirements

### DIFF
--- a/docs/en/ch340_driver.rst
+++ b/docs/en/ch340_driver.rst
@@ -4,5 +4,10 @@ CH340 Driver
 ===============
 
   * `Windows V3.5 <https://github.com/wemos/ch340_driver/raw/master/CH341SER_WIN_3.5.ZIP>`_
-  * `Mac OSX V1.5 <https://github.com/wemos/ch340_driver/raw/master/CH341SER_MAC_1.5.ZIP>`_
+  * `Mac OSX (Pre 10.14 Mojave *only*) V1.5 <https://github.com/wemos/ch340_driver/raw/master/CH341SER_MAC_1.5.ZIP>`_
 
+.. note::  
+  For Mac OSX 10.14 and greater, do not install any supplimentary drivers. 
+  The drivers are now included with OSX. Installing the CH340 will cause a 
+  conflict and you will not be able to connect.
+  

--- a/docs/en/tutorials/d1/get_started_with_micropython_d1.rst
+++ b/docs/en/tutorials/d1/get_started_with_micropython_d1.rst
@@ -11,7 +11,6 @@ you can flash MicroPython firmware by yourself.
 Requirements
 ************************
 
-  * :doc:`../../ch340_driver`
   * `Python <https://www.python.org/downloads/>`_
   * `esptool <https://github.com/espressif/esptool>`_ (for flash esp8266&esp32 firmware.)
       
@@ -22,6 +21,11 @@ Requirements
       pip install esptool
 
   * `Micropython firmware <https://micropython.org/download#esp8266>`_ (esp8266)
+
+Additional Requirement for Mac OS X <10.14 (Mojave)
+************************
+
+  * :doc:`../../ch340_driver`
 
 Flash firmware
 ************************


### PR DESCRIPTION
CH340 drivers are no longer required as of OS X 10.14