### PR TITLE
s2 pico is very well supported by CircuitPython

### DIFF
--- a/docs/en/s2/s2_pico.rst
+++ b/docs/en/s2/s2_pico.rst
@@ -25,7 +25,7 @@ Features
 * 2MB PSRAM 
 * 21x IO
 * ADC, DAC, I2C, SPI, UART, USB OTG
-* Compatible with MicroPython, Arduino and ESP-IDF
+* Compatible with CircuitPython, MicroPython, Arduino and ESP-IDF
 * Default firmware: MicroPython
 
 Tutorials


### PR DESCRIPTION
edited "compatible with" section