### PR TITLE
Add CircuitPython to C3 Mini docs

### DIFF
--- a/docs/en/c3/c3_mini.rst
+++ b/docs/en/c3/c3_mini.rst
@@ -1,8 +1,8 @@
 C3 mini
 ================
 
-==================  ==================  
- |TOP_IMG|_           |BOTTOM_IMG|_  
+==================  ==================
+ |TOP_IMG|_           |BOTTOM_IMG|_
 ==================  ==================
 
 .. |TOP_IMG| image:: ../_static/boards/c3_mini_v1.0.0_1_16x16.jpg
@@ -11,7 +11,7 @@ C3 mini
 .. |BOTTOM_IMG| image:: ../_static/boards/c3_mini_v1.0.0_2_16x16.jpg
 .. _BOTTOM_IMG: ../_static/boards/c3_mini_v1.0.0_2_16x16.jpg
 
-A mini wifi & Bluetooth5 (LE) boards based ESP32-C3FH4. 
+A mini wifi & Bluetooth5 (LE) boards based ESP32-C3FH4.
 `[Buy it]`_
 
 .. _[Buy it]: https://www.aliexpress.com/item/1005004005736554.html
@@ -23,8 +23,8 @@ Features
 * 4MB Flash
 * 12x IO
 * ADC, I2C, SPI, UART
-* Compatible with LOLIN D1 mini shields 
-* Compatible with MicroPython, Arduino and ESP-IDF
+* Compatible with LOLIN D1 mini shields
+* Compatible with Arduino, CircuitPython, ESP-IDF, and MicroPython
 * Default firmware: MicroPython
 
 Tutorials
@@ -70,4 +70,3 @@ Pin
 
 .. image:: ../_static/boards/c3_mini_v1.0.0_4_16x9.jpg
    :target: ../_static/boards/c3_mini_v1.0.0_4_16x9.jpg
-

--- a/docs/en/tutorials/c3/get_started_with_circuitpython_c3.rst
+++ b/docs/en/tutorials/c3/get_started_with_circuitpython_c3.rst
@@ -1,0 +1,81 @@
+Get started with MicroPython [C3 series]
+=======================================================
+
+Flash MicroPython firmware
+----------------------------
+
+The boards were already flashed with MicroPython firmware.
+If they lost the firmware or you need the latest version, 
+you can flash MicroPython firmware by yourself.
+
+Requirements
+---------------
+
+* `Python <https://www.python.org/downloads/>`_
+* `esptool <https://github.com/espressif/esptool>`_ (to flash ESP32-C3 firmware)
+    
+.. highlight:: bash
+
+::
+
+      pip3 install esptool
+      
+C3 Firmware
+------------------
+
+.. * `C3 Mini Firmware <https://micropython.org/download/LOLIN_C3_MINI/>`_
+
+* `C3 Mini Firmware <https://github.com/wemos/micropython/releases/download/v1.16/firmware.bin>`_
+
+
+Flash firmware
+-------------------
+* Put C3 boards into **Device Firmware Upgrade (DFU)** mode.
+
+  * Hold **Button 9**
+  * Press **Button Reset**
+  * Release **Button 9** when you hear the prompt tone on USB reconnection
+
+* Flash using esptool.py
+
+  .. highlight:: bash
+
+  ::
+
+    esptool.py --port PORT_NAME erase_flash
+    esptool.py --port PORT_NAME --baud 1000000 write_flash -z 0 FIRMWARE.bin
+
+.. note::  
+  Don't forget to change **PORT_NAME** and **FIRMWARE.bin**.
+  
+  In Linux, **PORT_NAME** is like /dev/ttyUSB0.
+  In Windows, **PORT_NAME** is like COM4.
+
+
+WIFI
+------------------
+You need set WIFI Tx Power to 8.5dBm to use WIFI.
+
+Use **sta_if.config(txpower=8.5)** after **sta_if.active(True)**
+
+.. code-block:: python
+  
+  def do_connect():
+    import network
+    sta_if = network.WLAN(network.STA_IF)
+    
+    if not sta_if.isconnected():
+        print('connecting to network...')
+        sta_if.active(True)
+        sta_if.config(txpower=8.5) 
+        sta_if.connect('ssid', 'passwd')
+        while not sta_if.isconnected():
+            pass
+    print('network config:', sta_if.ifconfig())
+
+Quick reference
+-------------------------
+* `Quick reference for the ESP32 <https://docs.micropython.org/en/latest/esp32/quickref.html>`_
+  
+
+

--- a/docs/en/tutorials/c3/get_started_with_circuitpython_c3.rst
+++ b/docs/en/tutorials/c3/get_started_with_circuitpython_c3.rst
@@ -62,7 +62,3 @@ Use **sta_if.config(txpower=8.5)** after **sta_if.active(True)**
 
   wifi.radio.tx_power = 8.5
   wifi.radio.connect("wifi_ssid", "wifi_password")
-
-Quick reference
--------------------------
-* `Quick reference for the ESP32 <https://docs.micropython.org/en/latest/esp32/quickref.html>`_

--- a/docs/en/tutorials/c3/get_started_with_circuitpython_c3.rst
+++ b/docs/en/tutorials/c3/get_started_with_circuitpython_c3.rst
@@ -4,28 +4,26 @@ Get started with MicroPython [C3 series]
 Flash MicroPython firmware
 ----------------------------
 
-The boards were already flashed with MicroPython firmware.
-If they lost the firmware or you need the latest version, 
-you can flash MicroPython firmware by yourself.
+The boards were originally flashed with MicroPython firmware.
+To install CircuitPython flash the firmware with the following steps.
 
 Requirements
 ---------------
 
 * `Python <https://www.python.org/downloads/>`_
 * `esptool <https://github.com/espressif/esptool>`_ (to flash ESP32-C3 firmware)
-    
+
 .. highlight:: bash
 
 ::
 
       pip3 install esptool
-      
-C3 Firmware
+
+C3 CircuitPython Firmware
 ------------------
 
-.. * `C3 Mini Firmware <https://micropython.org/download/LOLIN_C3_MINI/>`_
+.. * `C3 Mini Firmware <https://circuitpython.org/board/lolin_c3_mini/>`_
 
-* `C3 Mini Firmware <https://github.com/wemos/micropython/releases/download/v1.16/firmware.bin>`_
 
 
 Flash firmware
@@ -43,11 +41,11 @@ Flash firmware
   ::
 
     esptool.py --port PORT_NAME erase_flash
-    esptool.py --port PORT_NAME --baud 1000000 write_flash -z 0 FIRMWARE.bin
+    esptool.py --chip esp32c3 --port PORT_NAME --baud 460800 write_flash -z 0x0 firmware.bin
 
-.. note::  
+.. note::
   Don't forget to change **PORT_NAME** and **FIRMWARE.bin**.
-  
+
   In Linux, **PORT_NAME** is like /dev/ttyUSB0.
   In Windows, **PORT_NAME** is like COM4.
 
@@ -59,23 +57,12 @@ You need set WIFI Tx Power to 8.5dBm to use WIFI.
 Use **sta_if.config(txpower=8.5)** after **sta_if.active(True)**
 
 .. code-block:: python
-  
-  def do_connect():
-    import network
-    sta_if = network.WLAN(network.STA_IF)
-    
-    if not sta_if.isconnected():
-        print('connecting to network...')
-        sta_if.active(True)
-        sta_if.config(txpower=8.5) 
-        sta_if.connect('ssid', 'passwd')
-        while not sta_if.isconnected():
-            pass
-    print('network config:', sta_if.ifconfig())
+
+  import wifi
+
+  wifi.radio.tx_power = 8.5
+  wifi.radio.connect("wifi_ssid", "wifi_password")
 
 Quick reference
 -------------------------
 * `Quick reference for the ESP32 <https://docs.micropython.org/en/latest/esp32/quickref.html>`_
-  
-
-


### PR DESCRIPTION
We [added the C3 Mini to CircuitPython](https://github.com/adafruit/circuitpython/pull/6256), updating the docs to indicate that. I also removed unneeded spaces and alphabetized a couple of things.